### PR TITLE
Repository standards: CODEOWNERS, Dependabot, CodeQL, Trivy, CI hardening

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Default code owners (update to your teams as needed)
+* @KarimHassan
+
+# Scoped ownership examples
+internal/ @KarimHassan
+internal/relay/ @KarimHassan
+internal/web/ @KarimHassan
+.github/workflows/ @KarimHassan
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,35 @@
 name: CI/CD Pipeline
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main, develop]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'announcements/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '**/*.png'
+      - '**/*.jpg'
+      - '**/*.svg'
   pull_request:
     branches: [main, develop]
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'announcements/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '**/*.png'
+      - '**/*.jpg'
+      - '**/*.svg'
   release:
     types: [published]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   GO_VERSION: "1.24.1"
@@ -24,6 +47,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: true
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
@@ -42,25 +66,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-
-      - name: Prepare module cache
-        run: |
-          # Ensure clean state for module cache
-          mkdir -p ~/go/pkg/mod
-          chmod -R u+w ~/go/pkg/mod 2>/dev/null || true
-
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-        continue-on-error: true
-
-      - name: Clean module cache on conflict
-        if: failure()
-        run: go clean -modcache
+          cache: true
 
       - name: Download dependencies
         run: go mod download
@@ -82,7 +88,6 @@ jobs:
       - name: Run tests
         run: |
           go test -v -race -coverprofile=coverage.out ./...
-          go tool cover -html=coverage.out -o coverage.html
         env:
           SHUGUR_DB_HOST: localhost
           SHUGUR_DB_PORT: 26257
@@ -126,9 +131,10 @@ jobs:
           staticcheck ./...
 
   build:
-    name: Build
+    name: Build (main)
     runs-on: ubuntu-latest
     needs: [lint, test]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     strategy:
       matrix:
         goos: [linux, darwin, windows]
@@ -144,6 +150,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache: true
 
       - name: Build binary
         run: |
@@ -300,3 +307,26 @@ jobs:
             COMMIT=${{ github.sha }}
             DATE=${{ github.event.head_commit.timestamp }}
           target: production
+
+  build-pr:
+    name: Build (PR linux/amd64)
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Build binary (linux/amd64)
+        run: |
+          mkdir -p dist
+          VERSION=$(cat VERSION 2>/dev/null || echo "dev")
+          GOOS=linux GOARCH=amd64 go build \
+            -ldflags "-w -s -X main.version=${VERSION} -X main.commit=${{ github.sha }} -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -o dist/relay-linux-amd64 \
+            ./cmd

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,35 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    - cron: '0 3 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (Go)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: go
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,29 @@
+name: Trivy Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  trivy-fs:
+    name: Trivy FS Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Trivy filesystem scan (CRITICAL,HIGH)
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          scan-type: fs
+          ignore-unfixed: true
+          format: table
+          severity: CRITICAL,HIGH
+          exit-code: '1'
+          vuln-type: 'os,library'
+          hide-progress: true
+


### PR DESCRIPTION
This PR standardizes repository configuration and CI.\n\n- Add CODEOWNERS (defaults to @KarimHassan; adjust to teams as needed)\n- Enable Dependabot for gomod and GitHub Actions (weekly)\n- Add CodeQL scanning for Go (push/PR + weekly cron)\n- Add Trivy filesystem scan (CRITICAL,HIGH) on PRs and main pushes\n- CI hardening:\n  - Add default minimal permissions\n  - Add paths-ignore to skip docs/assets only changes\n  - Add concurrency to cancel stale runs\n  - Enable setup-go cache\n  - Split builds: PR builds linux/amd64 only; full matrix on main\n  - Keep Docker pushes on main/releases\n\nNo application code changes. This should make the repo more secure, faster, and cheaper to build.\n