### PR TITLE
perf: preallocate 500 events for query results (fixed cap)

### DIFF
--- a/internal/storage/queries.go
+++ b/internal/storage/queries.go
@@ -43,11 +43,12 @@ func (db *DB) GetEvents(ctx context.Context, filter nostr.Filter) ([]nostr.Event
 	}
 	defer rows.Close()
 
-    // Pre-allocate results slice with a small fixed cap to avoid
-    // any risk from user-controlled limits influencing allocation size.
-    // This is a performance hint only; appending will grow the slice as needed.
-    const defaultQueryPrealloc = 100
-    events := make([]nostr.Event, 0, defaultQueryPrealloc)
+	// Pre-allocate results slice with a fixed cap to avoid
+	// any user‑influenced allocation size. 500 matches the
+	// typical filter cap used by the relay and reduces slice
+	// growth for common queries while keeping memory modest.
+	const defaultQueryPrealloc = 500
+	events := make([]nostr.Event, 0, defaultQueryPrealloc)
 
 	// Process rows
 	for rows.Next() {


### PR DESCRIPTION
Use a fixed preallocation of 500 in GetEvents to match the relay's typical filter cap and reduce slice growth for common queries. Keeps allocation independent of user input to satisfy CodeQL.\n\nFile: internal/storage/queries.go